### PR TITLE
Made filenames from stack traces in result view clickable.

### DIFF
--- a/lib/clickable-paths.coffee
+++ b/lib/clickable-paths.coffee
@@ -1,0 +1,51 @@
+fs      = require 'fs'
+path    = require 'path'
+{Point} = require 'atom'
+{$}     = require 'atom-space-pen-views'
+
+PATH_REGEX = /((?:\w:)?[^:\s\(\)]+):(\d+):(\d+)/g
+
+module.exports.link = (line) ->
+  return null unless line?
+  line.replace(PATH_REGEX,'<a class="flink newFLink">$&</a>')
+
+
+module.exports.attachClickHandler = ->
+  $('.newFLink').on 'click', module.exports.clicked
+  .removeClass('.newFLink') # remove "new" marker
+
+
+module.exports.clicked = ->
+  extendedPath = this.innerHTML
+  module.exports.open(extendedPath)
+
+
+module.exports.open = (extendedPath) ->
+  parts = PATH_REGEX.exec(extendedPath)
+  return unless parts?
+
+  [filename,row,col] = parts.slice(1)
+  return unless filename?
+
+  projectPath = atom.project?.getPath()
+
+  if projectPath?
+    filename = path.resolve(projectPath,filename)
+
+  unless fs.existsSync(filename)
+    alert "File not found: #{filename}"
+    return
+
+  atom.workspace.open(filename)
+  .then ->
+
+    return unless row?
+    col ?= 0
+
+    editor = atom.workspace.getActiveTextEditor()
+    return unless editor?
+
+    position = new Point(row, col)
+
+    editor.scrollToBufferPosition(position, center:true)
+    editor.setCursorBufferPosition(position)

--- a/lib/clickable-paths.coffee
+++ b/lib/clickable-paths.coffee
@@ -38,14 +38,15 @@ module.exports.open = (extendedPath) ->
 
   atom.workspace.open(filename)
   .then ->
-
     return unless row?
-    col ?= 0
+
+    # align coordinates 0-index-based
+    row = Math.max(row - 1, 0)
+    col = Math.max(~~col - 1, 0)
+    position = new Point(row, col)
 
     editor = atom.workspace.getActiveTextEditor()
     return unless editor?
-
-    position = new Point(row, col)
 
     editor.scrollToBufferPosition(position, center:true)
     editor.setCursorBufferPosition(position)

--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -7,6 +7,8 @@ ansi   = require 'ansi-html-stream'
 psTree = require 'ps-tree'
 spawn  = require('child_process').spawn
 
+clickablePaths = require './clickable-paths'
+
 module.exports = class MochaWrapper extends events.EventEmitter
 
   constructor: (@context, debugMode = false) ->
@@ -53,7 +55,7 @@ module.exports = class MochaWrapper extends events.EventEmitter
       stream = ansi(chunked: false)
       @mocha.stdout.pipe stream
       @mocha.stderr.pipe stream
-      stream.on 'data', (data) => @emit 'output', data.toString()
+      stream.on 'data', (data) => @emit 'output', clickablePaths.link data.toString()
 
     @mocha.on 'error', (err) =>
       @emit 'error', err

--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -1,4 +1,5 @@
 {$, $$$, View} = require 'atom-space-pen-views'
+clickablePaths = require './clickable-paths'
 
 module.exports =
 class ResultView extends View
@@ -45,6 +46,7 @@ class ResultView extends View
   addLine: (line) ->
     if line isnt '\n'
       @results.append line
+      clickablePaths.attachClickHandler()
 
   success: ->
     @heading.addClass 'alert-success'

--- a/styles/mocha-test-runner.less
+++ b/styles/mocha-test-runner.less
@@ -60,6 +60,10 @@
     background-color: #181818;
     color: #F8F8F8;
     font-size: @font-size;
+
+    a {
+      color: #F8F8F8;
+    }
   }
 
 }


### PR DESCRIPTION
(Had to be done in two steps using jQuery due to atom's Content Security Policy)