### PR TITLE
Use the complete header as resize handler.

### DIFF
--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -8,7 +8,6 @@ class ResultView extends View
 
   @content: ->
     @div class: 'mocha-test-runner', =>
-      @div outlet: 'resizeHandle', class: 'resize-handle'
       @div class: 'panel', =>
         @div outlet: 'heading', class: 'heading', =>
           @div class: 'pull-right', =>
@@ -24,7 +23,7 @@ class ResultView extends View
 
     @heading.on 'dblclick', => @toggleCollapse()
     @closeButton.on 'click', => atom.commands.dispatch this, 'result-view:close'
-    @resizeHandle.on 'mousedown', (e) => @resizeStarted e
+    @heading.on 'mousedown', (e) => @resizeStarted e
     @results.addClass 'native-key-bindings'
     @results.attr 'tabindex', -1
 

--- a/styles/mocha-test-runner.less
+++ b/styles/mocha-test-runner.less
@@ -10,14 +10,6 @@
   -webkit-flex-direction: column;
   min-height: @font-size + 2 * @component-padding;
 
-  .resize-handle {
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: 10px;
-    cursor: row-resize;
-  }
-
   .panel {
 
     display: -webkit-flex;
@@ -30,6 +22,7 @@
     .close-icon {
 
       padding: @component-icon-padding;
+      cursor: initial;
 
       &:before {
         font-family: 'Octicons Regular';
@@ -48,6 +41,7 @@
       flex-shrink: 0;
       padding: @component-padding;
       color: black;
+      cursor: row-resize;
     }
 
     .panel-body {


### PR DESCRIPTION
This makes it easier to interact with the view. The "double-click on header" action was already a kind of "resize" method.

Made resizeHandler obsolete