### PR TITLE
Improved Windows support

### DIFF
--- a/lib/context.coffee
+++ b/lib/context.coffee
@@ -2,11 +2,13 @@ fs   = require 'fs'
 path = require 'path'
 util = require 'util'
 selectedTest = require './selected-test'
+isWindows = ///^win///.test process.platform
 
 exports.find = (editor) ->
   root = closestPackage editor.getPath()
   if root
-    mochaBinary = path.join root, 'node_modules', '.bin', 'mocha'
+    mochaCommand = if isWindows then 'mocha.cmd' else 'mocha'
+    mochaBinary = path.join root, 'node_modules', '.bin', 'mocha.cmd'
     if not fs.existsSync mochaBinary
       mochaBinary = 'mocha'
     root: root

--- a/lib/context.coffee
+++ b/lib/context.coffee
@@ -8,7 +8,7 @@ exports.find = (editor) ->
   root = closestPackage editor.getPath()
   if root
     mochaCommand = if isWindows then 'mocha.cmd' else 'mocha'
-    mochaBinary = path.join root, 'node_modules', '.bin', 'mocha.cmd'
+    mochaBinary = path.join root, 'node_modules', '.bin', mochaCommand
     if not fs.existsSync mochaBinary
       mochaBinary = 'mocha'
     root: root

--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -6,6 +6,7 @@ escape = require 'jsesc'
 ansi   = require 'ansi-html-stream'
 psTree = require 'ps-tree'
 spawn  = require('child_process').spawn
+kill   = require 'tree-kill'
 
 clickablePaths = require './clickable-paths'
 
@@ -99,7 +100,8 @@ killTree = (pid, signal, callback) ->
     childrenPid = children.map (p) -> p.PID
     [pid].concat(childrenPid).forEach (tpid) ->
       try
-        process.kill tpid, signal
+        kill tpid, signal
+        # process.kill tpid, signal
       catch ex
         console.log "Failed to #{signal} #{tpid}"
     callback()

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   },
   "dependencies": {
     "ansi-html-stream": "0.0.3",
+    "atom-space-pen-views": "^2.0.3",
     "jsesc": "~0.4.3",
     "localeval": "~13.12.11",
     "ps-tree": "0.0.3",
-    "atom-space-pen-views": "^2.0.3"
+    "tree-kill": "0.0.6"
   }
 }


### PR DESCRIPTION
Switches mocha binary from `mocha` to `mocha.cmd` in Windows (fixes #23).
Also fixes the `'ps' could not be spawned` error when attempting to use `process.kill` by making use of the [`tree-kill`](https://www.npmjs.com/package/tree-kill) module to kill the process.

Needs to be tested by someone on Unix before you accept this PR. As far as I can tell, it should work, but give it a go.