### PR TITLE
Remove the need to get the project path when clicking link

### DIFF
--- a/lib/clickable-paths.coffee
+++ b/lib/clickable-paths.coffee
@@ -28,11 +28,6 @@ module.exports.open = (extendedPath) ->
   [filename,row,col] = parts.slice(1)
   return unless filename?
 
-  projectPath = atom.project?.getPath()
-
-  if projectPath?
-    filename = path.resolve(projectPath,filename)
-
   unless fs.existsSync(filename)
     alert "File not found: #{filename}"
     return


### PR DESCRIPTION
@rprieto 

This relates to #33 
`Project.getPath` is deprecated for `Project.getPaths` as you can have multiple projects open in the atom editor

I had a quick look at the code and I'm not sure we need to get the project path anyway
All the clickable links seem to be absolute paths

e.g. 
```
at Object.fail (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/assert.js:85:29)
   at failAssertion (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/assert.js:46:24)
   at Object.assert.(anonymous function) [as calledWith] (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/assert.js:69:21)
   at /Users/nguyenchr/Documents/Dev/my-project/test/models/my-model.spec.coffee:46:22
   at /Users/nguyenchr/Documents/Dev/my-project/src/models/my-model.coffee:25:5
   at callCallback (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/behavior.js:105:26)
   at Object.invoke (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/behavior.js:128:17)
   at Object.functionStub (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/stub.js:67:61)
   at Function.invoke (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/spy.js:157:59)
   at Object.proxy (/Users/nguyenchr/Documents/Dev/my-project/node_modules/sinon/lib/sinon/spy.js:74:30)
```

so we are doing something like 
```coffee
path.resolve '/Users/nguyenchr/Documents/Dev/my-project', '/Users/nguyenchr/Documents/Dev/my-project/src/models/my-model.coffee'
```

I might be missing an edge case where the filename is not absolute, but I havn't come across it yet