### PR TITLE
Use colour flags for text only output

### DIFF
--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -46,9 +46,9 @@ module.exports = class MochaWrapper extends events.EventEmitter
         env[key] = value
 
     if @textOnly
-      flags.push '-C'
+      flags.push '--no-colors'
     else
-      flags.push '-c'
+      flags.push '--colors'
 
     if @context.grep
       flags.push '--grep'

--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -46,7 +46,9 @@ module.exports = class MochaWrapper extends events.EventEmitter
         env[key] = value
 
     if @textOnly
-      flags.push '--no-colors'
+      flags.push '-C'
+    else
+      flags.push '-c'
 
     if @context.grep
       flags.push '--grep'


### PR DESCRIPTION
@rprieto 

as discussed in https://github.com/TabDigital/atom-mocha-test-runner/issues/36
Use flags `-c | -C` for colour output and text-only output 