### PR TITLE
Display statistics when running in textOnly mode

### DIFF
--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -63,8 +63,12 @@ module.exports = class MochaWrapper extends events.EventEmitter
     @mocha = spawn @context.mocha, flags, opts
 
     if @textOnly
-      @mocha.stdout.on 'data', (data) => @emit 'output', data.toString()
-      @mocha.stderr.on 'data', (data) => @emit 'output', data.toString()
+      @mocha.stdout.on 'data', (data) =>
+        @parseStatistics data
+        @emit 'output', data.toString()
+      @mocha.stderr.on 'data', (data) =>
+        @parseStatistics data
+        @emit 'output', data.toString()
     else
       stream = ansi(chunked: false)
       @mocha.stdout.pipe stream


### PR DESCRIPTION
Was not showing the statistics in the header when in textOnly mode

e.g
![image](https://cloud.githubusercontent.com/assets/5554109/8721630/8d05589e-2bff-11e5-9102-81788e011860.png)
