### PR TITLE
Add height to .panel-body to allow scrolling

### DIFF
--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -60,6 +60,10 @@ class ResultView extends View
     @headingText.html "#{DEFAULT_HEADING_TEXT}..."
     @results.empty()
 
+  updateResultPanelHeight: ->
+    panelBody = @find '.panel-body'
+    panelBody.height (@height() - @heading.outerHeight())
+
   addLine: (line) ->
     if line isnt '\n'
       @results.append line
@@ -67,10 +71,12 @@ class ResultView extends View
   success: (stats) ->
     @heading.removeClass 'alert-info'
     @heading.addClass 'alert-success'
+    @updateResultPanelHeight()
 
   failure: (stats) ->
     @heading.removeClass 'alert-info'
     @heading.addClass 'alert-danger'
+    @updateResultPanelHeight()
 
   updateSummary: (stats) ->
     return unless stats?.length


### PR DESCRIPTION
`.panel-body` has `overflow-y: scroll` but no height is defined. This prevents scrolling on the result panel.

This pull request adds `updateResultPanelHeight()` that is called after Mocha finishes running tests (to wait for `.heading` to finish rendering).
`updateResultPanelHeight()` sets the height of `.panel-body` with the value of the total `ResultView` height subtracted by the height of `.heading`.