### PR TITLE
Improved Windows support

### DIFF
--- a/lib/mocha-test-runner.coffee
+++ b/lib/mocha-test-runner.coffee
@@ -1,4 +1,5 @@
 path        = require 'path'
+os          = require 'os'
 context     = require './context'
 Mocha       = require './mocha'
 ResultView  = require './result-view'
@@ -13,7 +14,7 @@ module.exports =
   config: # They are only read upon activation (atom bug?), thus the activationCommands for "settings-view:open" in package.json
     nodeBinaryPath:
       type: 'string'
-      default: '/usr/local/bin/node'
+      default: if os.platform() is 'win32' then 'C:\\Program Files\\nodejs\\node.exe' else '/usr/local/bin/node'
       description: 'Path to the node executable'
     textOnlyOutput:
       type: 'boolean'


### PR DESCRIPTION
Running on Windows, I had the same problem of issue [#23](https://github.com/TabDigital/atom-mocha-test-runner/issues/23). The proposed solution was a merge request [#24](https://github.com/TabDigital/atom-mocha-test-runner/pull/24) + [adding a node.cmd](https://github.com/TabDigital/atom-mocha-test-runner/issues/23#issuecomment-77752795) for each project root that uses atom-mocha-test-runner with the following contents:

```
@echo off
"C:\Program Files\nodejs\node.exe" %*
```

To avoid this extra step, I've added to **lib/mocha-test-runner.coffee** another default path verifying if the user is running on Windows.

I'd like to avoid this hard coded paths, but I could not find another way and I've seen
two others projects using the same approach.

Note that os.platform() returns 'win32' even for 64 machines. 