### PR TITLE
Fixed issue when closing test runner panel in windows.

### DIFF
--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -4,7 +4,6 @@ util   = require 'util'
 events = require 'events'
 escape = require 'jsesc'
 ansi   = require 'ansi-html-stream'
-psTree = require 'ps-tree'
 spawn  = require('child_process').spawn
 kill   = require 'tree-kill'
 
@@ -98,16 +97,6 @@ module.exports = class MochaWrapper extends events.EventEmitter
       @stats.push(stat)
       @emit 'updateSummary', @stats
 
-
-killTree = (pid, signal, callback) ->
-  signal = signal or 'SIGKILL'
-  callback = callback or (->)
-  psTree pid, (err, children) ->
-    childrenPid = children.map (p) -> p.PID
-    [pid].concat(childrenPid).forEach (tpid) ->
-      try
-        kill tpid, signal
-        # process.kill tpid, signal
-      catch ex
-        console.log "Failed to #{signal} #{tpid}"
-    callback()
+killTree = (pid) ->
+    kill pid, 'SIGKILL', (err) ->
+      console.log "Error killing process tree #{err}"

--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -98,5 +98,5 @@ module.exports = class MochaWrapper extends events.EventEmitter
       @emit 'updateSummary', @stats
 
 killTree = (pid) ->
-    kill pid, 'SIGKILL', (err) ->
+    kill pid, 'SIGTERM', (err) ->
       console.log "Error killing process tree #{err}"

--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -53,6 +53,7 @@ class ResultView extends View
   resizeView: ({pageY}) =>
     headingHeight =  @heading.outerHeight()
     @height Math.max(@resizeData.height + @resizeData.pageY - pageY,headingHeight)
+    @updateResultPanelHeight()
 
   reset: ->
     @heading.removeClass 'alert-success alert-danger'


### PR DESCRIPTION
Fixed an error in Windows caused by ps-Tree when you closed the test runner window. Replaced ps-Tree with tree-kill and tested with Linux and Windows and found it working correctly. I would also recommend someone else test this with a Mac, since I don't have one. Tree-kill should kill the entire tree as well as the root process per the documentation, so I got rid of the gathering and killing of the children code. 