### PR TITLE
add mochaBinary support, pass in current PATH to mocha instantiation

### DIFF
--- a/lib/context.coffee
+++ b/lib/context.coffee
@@ -7,7 +7,7 @@ isWindows = ///^win///.test process.platform
 exports.find = (editor) ->
   root = closestPackage editor.getPath()
   if root
-    mochaCommand = if isWindows then 'mocha.cmd' else 'mocha'
+    mochaCommand = atom.config.get 'mocha-test-runner.mochaCommand'
     mochaBinary = path.join root, 'node_modules', '.bin', mochaCommand
     if not fs.existsSync mochaBinary
       mochaBinary = 'mocha'
@@ -19,7 +19,7 @@ exports.find = (editor) ->
     root: path.dirname editor.getPath()
     test: path.basename editor.getPath()
     grep: selectedTest.fromEditor editor
-    mocha: 'mocha'
+    mocha: atom.config.get 'mocha-test-runner.mochaCommand'
 
 closestPackage = (folder) ->
   pkg = path.join folder, 'package.json'

--- a/lib/mocha-test-runner.coffee
+++ b/lib/mocha-test-runner.coffee
@@ -16,6 +16,10 @@ module.exports =
       type: 'string'
       default: if os.platform() is 'win32' then 'C:\\Program Files\\nodejs\\node.exe' else '/usr/local/bin/node'
       description: 'Path to the node executable'
+    mochaCommand:
+      type: 'string'
+      default: if os.platform() is 'win32' then 'mocha.cmd' else 'mocha'
+      description: 'Command to run mocha'
     textOnlyOutput:
       type: 'boolean'
       default: false
@@ -87,6 +91,7 @@ module.exports =
       nodeBinary = atom.config.get 'mocha-test-runner.nodeBinaryPath'
       resultView.addLine "Node binary:    #{nodeBinary}\n"
       resultView.addLine "Root folder:    #{currentContext.root}\n"
+      resultView.addLine "Mocha command:  #{currentContext.mochaCommand}\n"
       resultView.addLine "Path to mocha:  #{currentContext.mocha}\n"
       resultView.addLine "Debug-Mode:     #{inDebugMode}\n"
       resultView.addLine "Test file:      #{currentContext.test}\n"

--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -17,6 +17,7 @@ module.exports = class MochaWrapper extends events.EventEmitter
   constructor: (@context, debugMode = false) ->
     @mocha = null
     @node = atom.config.get 'mocha-test-runner.nodeBinaryPath'
+    @mochaCommand = atom.config.get 'mocha-test-runner.mochaCommand'
     @textOnly = atom.config.get 'mocha-test-runner.textOnlyOutput'
     @options = atom.config.get 'mocha-test-runner.options'
     @env = atom.config.get 'mocha-test-runner.env'
@@ -39,7 +40,7 @@ module.exports = class MochaWrapper extends events.EventEmitter
     ]
 
     env =
-      PATH: path.dirname(@node)
+      PATH: [process.env.PATH, path.dirname(@node)].join(':')
 
     if @env
       for index, name of @env.split ' '


### PR DESCRIPTION
1. adds the ability to specify the `mochaCommand` - this way one could use alternate test runners (like [mocha-webpack](https://github.com/zinserjan/mocha-webpack))
2. passes the process's `process.env.PATH` along to the child test process. 