### PR TITLE
Fix package.json resolution to prefer root with node_modules folder

### DIFF
--- a/lib/context.coffee
+++ b/lib/context.coffee
@@ -24,7 +24,11 @@ exports.find = (editor) ->
 closestPackage = (folder) ->
   pkg = path.join folder, 'package.json'
   if fs.existsSync pkg
-    folder
+    nm = path.join folder, 'node_modules'
+    if fs.existsSync nm
+      return folder
+    # Prefer package.json with node_modules if available.
+    closestPackage path.dirname(folder) ? folder
   else if folder is '/'
     null
   else


### PR DESCRIPTION
The project I'm working with has multiple nested `project.json` files (i.e., for submodules), but only the root one contains a valid mocha configuration and `node_modules`. This seems like a reasonable fix, but I don't know enough about other people's project structures to know if it would be problematic.