### PR TITLE
Inject package.json root folder to links

### DIFF
--- a/lib/clickable-paths.coffee
+++ b/lib/clickable-paths.coffee
@@ -5,10 +5,9 @@ path    = require 'path'
 
 PATH_REGEX = /((?:\w:)?[^:\s\(\)]+):(\d+):(\d+)/g
 
-module.exports.link = (line) ->
+module.exports.link = (line, root) ->
   return null unless line?
-  line.replace(PATH_REGEX,'<a class="flink">$&</a>')
-
+  line.replace(PATH_REGEX, "<a class=\"flink\" data-root=\"#{root}\">$&</a>")
 
 module.exports.attachClickHandler = ->
   $(document).on 'click', '.flink', module.exports.clicked
@@ -18,8 +17,8 @@ module.exports.removeClickHandler = ->
 
 module.exports.clicked = ->
   extendedPath = this.innerHTML
-  module.exports.open(extendedPath)
-
+  rootPath = this.getAttribute 'data-root'
+  module.exports.open(path.join rootPath, extendedPath)
 
 module.exports.open = (extendedPath) ->
   parts = PATH_REGEX.exec(extendedPath)

--- a/lib/mocha.coffee
+++ b/lib/mocha.coffee
@@ -79,7 +79,7 @@ module.exports = class MochaWrapper extends events.EventEmitter
       @mocha.stderr.pipe stream
       stream.on 'data', (data) =>
         @parseStatistics data
-        @emit 'output', clickablePaths.link data.toString()
+        @emit 'output', clickablePaths.link(data.toString(), @context.root)
 
     @mocha.on 'error', (err) =>
       @emit 'error', err


### PR DESCRIPTION
Hi!

I just don't know why, but on some simple projects, the reporter links are not working. But when I work on a mono repository project, the links just never works.

For example:
```
myrepo
  +- service1
  |  +- package.json
  |  +- src
  |    +- file1.js
  +- service2
     +- package.json
```

if I run a test on the `service1` project and an error occurs, the reporter will get the link `src/file1.js` and atom will try to open `myrepo/src/file1.js`…

As I've see on the Pull Request #34, mocha run with a context from the `package.json` file. So I decided to inject the root folder on a data attribute to avoid to long links on the reporter and to open the files from the `package.json` folder, not the project one.

If you have some ideas for a more elegant way to do this, please tell me 😄 

Thank you!